### PR TITLE
video is stopped after the page it is on is no longer visible

### DIFF
--- a/src/script/script.js
+++ b/src/script/script.js
@@ -512,13 +512,16 @@ $(document).ready(()=>{
         showOrHidePage("index");
         inputEl.focus();
         showOrHidePage("detail-page", false);
+        videoEl.attr("src", "" );
      });
 
      //user presses return back while in detail page
      returnBackBtn.on("click", ()=>{
-        showOrHidePage("detail-page", false);
+        
         showOrHidePage("index-games");
         showOrHidePage("games");
+        showOrHidePage("detail-page", false);
+        videoEl.attr("src", "" );
      });
 
      //display


### PR DESCRIPTION
video was playing in the background after returning back from the detail page.  This has been fixed.